### PR TITLE
fix(loader): allow repository model to control backoffice

### DIFF
--- a/spec/loader_spec.cr
+++ b/spec/loader_spec.cr
@@ -10,10 +10,10 @@ module PlaceOS::Frontends
       repository = example_repository
     end
 
-    it "implicity loads backoffice" do
+    it "implicity loads www base" do
       loader = Loader.new.start
 
-      Dir.exists?(File.join(TEST_DIR, "backoffice")).should be_true
+      Dir.exists?(File.join(TEST_DIR, "login")).should be_true
 
       loader.stop
     end

--- a/src/placeos-frontends/loader.cr
+++ b/src/placeos-frontends/loader.cr
@@ -46,7 +46,7 @@ module PlaceOS::Frontends
     end
 
     def start
-      create_backoffice
+      create_base_www
       start_update_cron
       super
     end
@@ -56,8 +56,8 @@ module PlaceOS::Frontends
       super
     end
 
-    # Frontend loader implicitly and idempotently creates a backoffice repository
-    protected def create_backoffice
+    # Frontend loader implicitly and idempotently creates a base www
+    protected def create_base_www
       content_directory_parent = Path[content_directory].parent.to_s
       Loader.clone_and_pull(
         repository_folder_name: content_directory,


### PR DESCRIPTION
`backoffice` is cloned on start in case DB cannot be reached.
Control the `backoffice` interface via entity created by init container.

Component of #2 