### PR TITLE
feat(loader): support branches

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -26,7 +26,7 @@ shards:
 
   clustering:
     git: https://github.com/place-labs/clustering.git
-    version: 2.0.0
+    version: 2.0.1
 
   connect-proxy:
     git: https://github.com/spider-gazelle/connect-proxy.git
@@ -102,7 +102,7 @@ shards:
 
   neuroplastic:
     git: https://github.com/spider-gazelle/neuroplastic.git
-    version: 1.6.0
+    version: 1.6.1
 
   openssl_ext:
     git: https://github.com/stakach/openssl_ext.git
@@ -118,11 +118,11 @@ shards:
 
   placeos-driver:
     git: https://github.com/placeos/driver.git
-    version: 3.4.3
+    version: 3.4.4
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 3.0.6
+    version: 3.1.1
 
   pool:
     git: https://github.com/ysbaddaden/pool.git
@@ -134,7 +134,7 @@ shards:
 
   promise:
     git: https://github.com/spider-gazelle/promise.git
-    version: 2.2.0
+    version: 2.2.1
 
   protobuf:
     git: https://github.com/jeromegn/protobuf.cr.git
@@ -182,7 +182,7 @@ shards:
 
   tasker:
     git: https://github.com/spider-gazelle/tasker.git
-    version: 1.3.0
+    version: 2.0.0
 
   tokenizer:
     git: https://github.com/spider-gazelle/tokenizer.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-frontends
-version: 0.9.0
+version: 0.10.0
 crystal: 0.35.1
 license: MIT
 

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -7,26 +7,55 @@ require "../src/placeos-frontends"
 
 TEST_DIR = "test-www"
 
-Spec.before_suite { reset }
+Spec.before_suite do
+  Log.builder.bind "*", Log::Severity::Debug, PlaceOS::Frontends::LOG_BACKEND
+  reset
+end
+
 Spec.after_suite { reset }
 
 PlaceOS::Frontends::Loader.configure do |settings|
   settings.content_directory = TEST_DIR
 end
 
-Log.builder.bind "*", Log::Severity::Debug, PlaceOS::Frontends::LOG_BACKEND
-
 def reset
   FileUtils.rm_rf(TEST_DIR)
 end
 
-def example_repository
-  existing = PlaceOS::Model::Repository.where(folder_name: "backoffice").first?
-  return existing if existing
+def example_branched_repository(branch : String = "test")
+  existing = PlaceOS::Model::Repository.where(folder_name: "ulid").first?
+  if existing
+    unless existing.branch == branch
+      existing.branch = branch
+      existing.save!
+    end
 
-  repository = PlaceOS::Model::Generator.repository(type: PlaceOS::Model::Repository::Type::Interface)
-  repository.uri = "https://github.com/place-labs/backoffice-release"
-  repository.name = "Backoffice"
-  repository.folder_name = "backoffice"
-  repository.save!
+    existing
+  else
+    repository = PlaceOS::Model::Generator.repository(type: PlaceOS::Model::Repository::Type::Interface)
+    repository.uri = "https://github.com/place-labs/ulid"
+    repository.name = "ulid"
+    repository.folder_name = "ulid"
+    repository.branch = branch
+
+    repository.save!
+  end
+end
+
+def example_repository(uri : String = "https://github.com/place-labs/backoffice-release")
+  existing = PlaceOS::Model::Repository.where(folder_name: "backoffice").first?
+  if existing
+    unless existing.uri == uri
+      existing.uri = uri
+      existing.save!
+    end
+
+    existing
+  else
+    repository = PlaceOS::Model::Generator.repository(type: PlaceOS::Model::Repository::Type::Interface)
+    repository.uri = uri
+    repository.name = "Backoffice"
+    repository.folder_name = "backoffice"
+    repository.save!
+  end
 end

--- a/spec/loader_spec.cr
+++ b/spec/loader_spec.cr
@@ -29,14 +29,76 @@ module PlaceOS::Frontends
     it "removes frontends" do
       loader = Loader.new.start
 
-      Dir.exists?(File.join(TEST_DIR, repository_folder_name)).should be_true
+      expected_path = File.join(TEST_DIR, repository_folder_name)
+
+      Dir.exists?(expected_path).should be_true
 
       repository.destroy
       sleep 0.5
 
-      Dir.exists?(File.join(TEST_DIR, repository_folder_name)).should be_false
+      Dir.exists?(expected_path).should be_false
 
       loader.stop
+    end
+
+    it "supports changing a uri" do
+      loader = Loader.new.start
+
+      expected_path = File.join(TEST_DIR, repository_folder_name)
+      expected_uri = "https://github.com/place-labs/backoffice-alpha"
+
+      Dir.exists?(expected_path).should be_true
+
+      repository.uri = expected_uri
+      repository.save!
+      after_load = loader.processed.size
+      while loader.processed.size == after_load
+        Fiber.yield
+      end
+
+      Dir.exists?(expected_path).should be_true
+      url = ExecFrom.exec_from(expected_path, "git", {"remote", "get-url", "origin"})[:output].to_s
+
+      url.strip.should end_with("backoffice-alpha")
+
+      loader.stop
+    end
+
+    describe "branches" do
+      it "loads a specific branch" do
+        repository = example_branched_repository("test")
+
+        loader = Loader.new.start
+        path = File.join(TEST_DIR, "ulid")
+
+        Dir.exists?(path).should be_true
+        Compiler::GitCommands.current_branch(path).should eq "test"
+
+        loader.stop
+      end
+
+      it "switches branches" do
+        repository = example_branched_repository("test")
+
+        loader = Loader.new.start
+        path = File.join(TEST_DIR, "ulid")
+
+        Dir.exists?(path).should be_true
+        Compiler::GitCommands.current_branch(path).should eq "test"
+
+        repository.branch = "master"
+        repository.save!
+
+        after_load = loader.processed.size
+        while loader.processed.size == after_load
+          Fiber.yield
+        end
+
+        Dir.exists?(path).should be_true
+        Compiler::GitCommands.current_branch(path).should eq "master"
+
+        loader.stop
+      end
     end
   end
 end

--- a/spec/repositories_spec.cr
+++ b/spec/repositories_spec.cr
@@ -11,6 +11,18 @@ module PlaceOS::Frontends::Api
       Api::Repositories.loader.stop
     end
 
+    it "lists branches for a loaded repository" do
+      repository = example_branched_repository
+      Api::Repositories.loader = Loader.new.start
+
+      branches = Api::Repositories.branches?(repository.folder_name.as(String))
+      branches.should_not be_nil
+      branches = branches.not_nil!
+      branches.size.should be > 0
+      branches.should contain("master")
+      Api::Repositories.loader.stop
+    end
+
     it "lists current commit for all loaded repositories" do
       repository = example_repository
       Api::Repositories.loader = Loader.new.start

--- a/src/placeos-frontends/client.cr
+++ b/src/placeos-frontends/client.cr
@@ -52,6 +52,14 @@ module PlaceOS::Frontends
       Array(NamedTuple(commit: String, date: String, author: String, subject: String)).from_json(response.body)
     end
 
+    # Branches for a frontend folder
+    def commits(folder_name : String)
+      path = "/repositories/#{folder_name}/branches"
+      response = get(path)
+
+      Array(String).from_json(response.body)
+    end
+
     ###########################################################################
 
     def initialize(


### PR DESCRIPTION
solves PlaceOS/models/issues/26

As referenced above, there is currently no API to list branches for a repository.
We may as well support branch listing for cloned repositories
In that case, we should hide the branch field in the form, then allow branch selection via the update form.